### PR TITLE
fix(config): create a config file on the first run

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,7 +3,7 @@ import { red } from 'colorette';
 import { program } from 'commander';
 import type { Issue } from 'cspell';
 import { lint } from 'cspell';
-import { findConfig } from './config';
+import { findOrCreateConfig } from './config';
 import {
 	reportErrors,
 	reportSuccess,
@@ -60,7 +60,7 @@ const globs = program.processedArgs[0];
 showStartupMessage(globs);
 
 const start = async () => {
-	const configPath = await findConfig(options.config);
+	const configPath = await findOrCreateConfig(options.config);
 	showConfigurationFilePath(configPath);
 
 	const {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,7 +4,15 @@ import { program } from 'commander';
 import type { Issue } from 'cspell';
 import { lint } from 'cspell';
 import { findConfig } from './config';
-import { reportErrors, reportSuccess, resetDisplay, showProgress, showStartupMessage, stopSpinner } from './display';
+import {
+	reportErrors,
+	reportSuccess,
+	resetDisplay,
+	showConfigurationFilePath,
+	showProgress,
+	showStartupMessage,
+	stopSpinner
+} from './display';
 import { handleIssues } from './handleIssue';
 
 interface CLIOptions {
@@ -53,6 +61,7 @@ showStartupMessage(globs);
 
 const start = async () => {
 	const configPath = await findConfig(options.config);
+	showConfigurationFilePath(configPath);
 
 	const {
 		issues: issueCount,

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,5 @@
 import { extname } from 'node:path';
+import { existsSync } from 'node:fs';
 import { readFile, writeFile } from 'node:fs/promises';
 import type { CSpellSettings } from 'cspell';
 import { searchForConfig } from 'cspell-lib';
@@ -7,17 +8,29 @@ import { previousState } from './shared';
 
 let configPath: string | undefined;
 
+export const writeToSettings = async (settings: CSpellSettings | { cspell: CSpellSettings }) => {
+	await writeFile(configPath!, JSON.stringify(settings, null, 4));
+};
+
 export const findConfig = async (config?: string) => {
 	// Try to locate a config file in the current working directory, or with the `config` option if it was provided.
 	const configSource = config ?? (await searchForConfig(process.cwd()))?.__importRef?.filename;
 
+	// LocalConfigPath is a path to a config file in the user's configuration directory (platform dependent).
+	const localConfigPath = (await import('application-config-path')).default('cspell.json');
+
 	// If no config file was found, use/create a config file in the user's configuration directory (platform dependent).
-	const path = configSource ?? (await import('application-config-path')).default('cspell.json');
+	const path = configSource ?? localConfigPath;
 
 	// Only JSON files are supported to prevent more dependencies for yml parsing. If the config file is not a JSON
 	// file, it can still be used, but it won't be updated with new ignored words.
 	if (extname(path) === '.json') {
 		configPath = path;
+	}
+
+	// If the path is the local config path and it doesn't exist, create it.
+	if (path === localConfigPath && !existsSync(localConfigPath)) {
+		await writeToSettings({});
 	}
 
 	return path;
@@ -35,10 +48,6 @@ export const getSettings = async (): Promise<CSpellSettings | { cspell: CSpellSe
 		// If the config file is invalid, it should be ignored.
 		configPath = undefined;
 	}
-};
-
-export const writeToSettings = async (settings: CSpellSettings | { cspell: CSpellSettings }) => {
-	await writeFile(configPath!, JSON.stringify(settings, null, 4));
 };
 
 export const addIgnoreWordToSettings = async (word: string) => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -3,6 +3,7 @@ import { existsSync } from 'node:fs';
 import { readFile, writeFile } from 'node:fs/promises';
 import type { CSpellSettings } from 'cspell';
 import { searchForConfig } from 'cspell-lib';
+import findDefaultConfigPath from 'application-config-path';
 // eslint-disable-next-line import/no-relative-packages
 import { previousState } from './shared';
 
@@ -17,10 +18,10 @@ export const findOrCreateConfig = async (config?: string) => {
 	const configSource = config ?? (await searchForConfig(process.cwd()))?.__importRef?.filename;
 
 	// LocalConfigPath is a path to a config file in the user's configuration directory (platform dependent).
-	const localConfigPath = (await import('application-config-path')).default('cspell.json');
+	const defaultConfigPath = findDefaultConfigPath('cspell.json');
 
 	// If no config file was found, use/create a config file in the user's configuration directory (platform dependent).
-	const path = configSource ?? localConfigPath;
+	const path = configSource ?? defaultConfigPath;
 
 	// Only JSON files are supported to prevent more dependencies for yml parsing. If the config file is not a JSON
 	// file, it can still be used, but it won't be updated with new ignored words.
@@ -29,7 +30,7 @@ export const findOrCreateConfig = async (config?: string) => {
 	}
 
 	// If the path is the local config path and it doesn't exist, create it.
-	if (path === localConfigPath && !existsSync(localConfigPath)) {
+	if (path === defaultConfigPath && !existsSync(defaultConfigPath)) {
 		await writeToSettings({});
 	}
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,7 +12,7 @@ export const writeToSettings = async (settings: CSpellSettings | { cspell: CSpel
 	await writeFile(configPath!, JSON.stringify(settings, null, 4));
 };
 
-export const findConfig = async (config?: string) => {
+export const findOrCreateConfig = async (config?: string) => {
 	// Try to locate a config file in the current working directory, or with the `config` option if it was provided.
 	const configSource = config ?? (await searchForConfig(process.cwd()))?.__importRef?.filename;
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,11 +17,8 @@ export const findOrCreateConfig = async (config?: string) => {
 	// Try to locate a config file in the current working directory, or with the `config` option if it was provided.
 	const configSource = config ?? (await searchForConfig(process.cwd()))?.__importRef?.filename;
 
-	// LocalConfigPath is a path to a config file in the user's configuration directory (platform dependent).
-	const defaultConfigPath = findDefaultConfigPath('cspell.json');
-
 	// If no config file was found, use/create a config file in the user's configuration directory (platform dependent).
-	const path = configSource ?? defaultConfigPath;
+	const path = configSource ?? findDefaultConfigPath('cspell.json');
 
 	// Only JSON files are supported to prevent more dependencies for yml parsing. If the config file is not a JSON
 	// file, it can still be used, but it won't be updated with new ignored words.
@@ -29,8 +26,8 @@ export const findOrCreateConfig = async (config?: string) => {
 		configPath = path;
 	}
 
-	// If the path is the local config path and it doesn't exist, create it.
-	if (path === defaultConfigPath && !existsSync(defaultConfigPath)) {
+	// If configSource is undefined, check if default config path exists. If it doesn't, create it.
+	if (!configSource && !existsSync(path)) {
 		await writeToSettings({});
 	}
 

--- a/src/display.ts
+++ b/src/display.ts
@@ -132,6 +132,10 @@ export const showStartupMessage = (globs: string[]) => {
 	console.log(`\nFinding files matching ${cyan(globs.join(', '))}`);
 };
 
+export const showConfigurationFilePath = (path: string) => {
+	console.log(`Using configuration from ${cyan(path)}\n`);
+};
+
 let spinner: Spinner | undefined;
 export const stopSpinner = () => {
 	spinner?.stop();

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -61,18 +61,16 @@ describe.each(allTypoSets)('%s', (name, data) => {
 
 describe('findConfig', () => {
 	test('should find a mock config file in working directory', async () => {
-		const readFileSpy = vi.spyOn<typeof fs, 'readFile'>(fs, 'readFile');
+		const configPath = join(process.cwd(), 'cspell.json');
+
+		const readFileSpy = vi.spyOn(fs, 'readFile');
 
 		readFileSpy.mockImplementation(((path: string, _encoding: any, callback: (err: null, data: string) => void) => {
-			if (path === join(process.cwd(), 'cspell.json')) {
-				callback(null, '{}');
-			} else {
-				callback(null, '');
-			}
+			callback(null, path === configPath ? '{}' : '');
 		}) as typeof fs.readFile);
 
 		const config = await findOrCreateConfig();
 
-		expect(config).toBe(join(process.cwd(), 'cspell.json'));
+		expect(config).toBe(configPath);
 	});
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -4,7 +4,7 @@ import { writeFile } from 'node:fs/promises';
 import { vi, afterEach, describe, test, expect } from 'vitest';
 import { handleIssues } from '../src/handleIssue';
 import { determineAction, formatContext } from '../src/display';
-import { findConfig } from '../src/config';
+import { findOrCreateConfig } from '../src/config';
 import { Action } from '../src/shared';
 import { allTypoSets } from './fixtures/data';
 import { sampleReplacer } from './mocks/issue';
@@ -63,11 +63,7 @@ describe('findConfig', () => {
 	test('should find a mock config file in working directory', async () => {
 		const readFileSpy = vi.spyOn<typeof fs, 'readFile'>(fs, 'readFile');
 
-		readFileSpy.mockImplementation(((
-			path: string,
-			_encoding: any,
-			callback: (err: NodeJS.ErrnoException | null, data: string) => void
-		) => {
+		readFileSpy.mockImplementation(((path: string, _encoding: any, callback: (err: null, data: string) => void) => {
 			if (path === join(process.cwd(), 'cspell.json')) {
 				callback(null, '{}');
 			} else {
@@ -75,7 +71,7 @@ describe('findConfig', () => {
 			}
 		}) as typeof fs.readFile);
 
-		const config = await findConfig();
+		const config = await findOrCreateConfig();
 
 		expect(config).toBe(join(process.cwd(), 'cspell.json'));
 	});


### PR DESCRIPTION
This PR fixes a problem where users, after installing `rspell` and running it for the first time, receive an error saying they don't have a `cspell.json`  on their default configuration paths.

The changes are adding the config file creation responsibility and renaming `findConfig` to `findOrCreateConfig`, also introducing tests for it.